### PR TITLE
Python client: Use accelerated protocol for Thrift, for a 2x speed boost.

### DIFF
--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -6,7 +6,7 @@ use_setuptools()
 from setuptools import setup, find_packages
 from os import path
 
-version = '0.0.2'
+version = '0.1.0'
 
 setup(
     name='SAPO-Broker',
@@ -25,13 +25,12 @@ setup(
         * SSL
         * Dropbox""",
     url="http://oss.sapo.pt/#!broker",
-    install_requires=['protobuf', 'thrift'],
+    install_requires=['thrift'],  # protobuf is optional, thrift is preferred
     version=version,
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.5',
         'Programming Language :: Python :: 2.6',
 	    'Programming Language :: Python :: 2.7',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/client/python/src/Broker/Codecs/Thrift.py
+++ b/client/python/src/Broker/Codecs/Thrift.py
@@ -207,7 +207,7 @@ class Codec:
 
         #serialization objects
         transportOut = TTransport.TMemoryBuffer()
-        protocolOut = TBinaryProtocol.TBinaryProtocol(transportOut)
+        protocolOut = TBinaryProtocol.TBinaryProtocolAccelerated(transportOut)
         atom.write(protocolOut)
 
         #get the message binary payload
@@ -221,7 +221,7 @@ class Codec:
         atom = ttypes.Atom()
 
         transportIn = TTransport.TMemoryBuffer(data)
-        protocolIn = TBinaryProtocol.TBinaryProtocol(transportIn)
+        protocolIn = TBinaryProtocol.TBinaryProtocolAccelerated(transportIn)
 
         atom.read(protocolIn)
         action = atom.action


### PR DESCRIPTION
This modifies Thrift serialization/deserialization in the Python client to use the accelerated protocol implementation. This gives a 2x speed boost to the `Minimal()` client, but the `Async()` client remains mostly the same (why this happens is something that has to be further investigated).